### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,4 @@ htmlcov/
 
 # Operating System
 .DS_Store
-Thumbs.db
+Thumbs.dbnode_modules/


### PR DESCRIPTION
This PR adds node_modules to .gitignore to prevent committing dependencies.

### Changes
- Add node_modules/ to .gitignore

### Next Steps
- Run `npm install` to install dependencies
- Follow development setup in README.md