### PR TITLE
Add GitHub Actions workflow for Flatpak builds

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,0 +1,46 @@
+name: Build Flatpak
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Flatpak
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+
+      - name: Add Flathub remote
+        run: |
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder --repo=repo --force-clean build-dir flatpak/com.frigateNVR.ConfigGUI.yml
+          flatpak build-bundle repo frigate-config-gui.flatpak com.frigateNVR.ConfigGUI
+
+      - name: Upload Flatpak bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: frigate-config-gui-flatpak
+          path: frigate-config-gui.flatpak
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: frigate-config-gui.flatpak
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically builds the Flatpak package.

### Changes
- Added `.github/workflows/build-flatpak.yml`
- Workflow triggers on:
  - Pushes to main
  - Version tags (v*)
  - Pull requests to main
- Builds Flatpak package and uploads as artifact
- Creates draft releases with Flatpak bundle for version tags

### Testing
Once merged, the workflow will automatically run on:
1. Every push to main
2. Every pull request
3. When version tags are pushed (e.g., v1.0.0)