### PR TITLE
Fix README and documentation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ⚠️ **IMPORTANT: This project is in early development and NOT ready for production use** ⚠️
 
-A desktop application for managing Frigate NVR configuration files through an intuitive graphical user interface. This project aims to be integrated into the main Frigate NVR project once it reaches maturity.
+A desktop application for managing Frigate NVR configuration files through an intuitive graphical user interface. This project aims to be adopted by the Frigate NVR organization once it reaches maturity.
 
 ## Project Status
 
@@ -89,4 +89,4 @@ Contributions are welcome! Please read our contributing guidelines (coming soon)
 
 ## License
 
-[License type to be determined]
+This project is licensed under the [MIT License](LICENSE)

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -4,7 +4,7 @@
 A desktop GUI application designed to simplify the configuration of Frigate NVR (Network Video Recorder). This is NOT just another YAML editor - it's a purpose-built tool that makes Frigate configuration accessible and intuitive for users of all technical levels.
 
 ### Long-term Vision
-This project is being developed with the intention of eventual integration into the main Frigate NVR project. The goal is to provide a robust, user-friendly configuration interface that can be seamlessly incorporated into Frigate's management interface once it reaches maturity.
+This project is being developed with the intention of eventual adoption by the Frigate NVR organization. The goal is to provide a robust, user-friendly configuration interface that can be seamlessly incorporated into Frigate's management interface once it reaches maturity.
 
 ### Key Design Principles
 1. **Example-Driven Configuration**


### PR DESCRIPTION
This PR fixes two issues in the documentation:

1. Changed wording from "integrated into" to "adopted by" when referring to the Frigate NVR organization
2. Updated license section to correctly show MIT license with link

Changes:
- Updated README.md to use correct wording and add MIT license link
- Updated SPECIFICATIONS.md for consistency in wording
- Maintained links to LICENSE file