### PR TITLE
Improve build script error handling and debugging

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Frigate Config GUI - Flatpak Build Script
+# 
+# This script builds the Frigate Config GUI application as a Flatpak package.
+# It handles downloading dependencies, validating checksums, and creating the final bundle.
+#
+# Usage:
+#   ./build.sh                   # Normal build
+#   FORCE_DOWNLOAD=true ./build.sh   # Force re-download of Node.js
+#
+# Environment variables:
+#   FORCE_DOWNLOAD  Set to "true" to force re-download of Node.js tarball (default: false)
+#   DEBUG          Set to "true" to show debug information even on success (default: false)
+#
+
 set -euo pipefail
 
 # Configuration
@@ -13,6 +28,10 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
+
+# Debug mode
+: "${DEBUG:=false}"  # Set to true to show debug info even on success
+: "${FORCE_DOWNLOAD:=false}"  # Set to true to force download of Node.js tarball
 
 # Function to check dependencies
 check_dependencies() {
@@ -42,31 +61,72 @@ update_node_sha256() {
     # Create downloads directory if it doesn't exist
     mkdir -p "$download_dir"
     
-    # Download the tarball
-    if ! curl -L "$node_url" -o "$tarball_path"; then
-        echo -e "${RED}Error: Failed to download Node.js tarball${NC}"
-        exit 1
+    # Download the tarball if it doesn't exist or if force download is requested
+    if [ ! -f "$tarball_path" ] || [ "${FORCE_DOWNLOAD:-false}" = "true" ]; then
+        echo "Downloading Node.js tarball..."
+        if ! curl -L "$node_url" -o "$tarball_path"; then
+            echo -e "${RED}Error: Failed to download Node.js tarball${NC}"
+            print_debug_info
+            exit 1
+        fi
+    else
+        echo "Using existing Node.js tarball..."
     fi
     
     # Compute SHA256
+    echo "Computing SHA256..."
     local new_sha256=$(sha256sum "$tarball_path" | cut -d' ' -f1)
     if [ -z "$new_sha256" ]; then
         echo -e "${RED}Error: Failed to compute SHA256${NC}"
+        print_debug_info
         exit 1
     fi
     
     # Update SHA256 in manifest
-    sed -i "s|sha256: [a-f0-9]\{64\}|sha256: $new_sha256|" "$MANIFEST_PATH"
+    echo "Updating manifest with SHA256: $new_sha256"
+    if ! sed -i "s|sha256: [a-f0-9]\{64\}|sha256: $new_sha256|" "$MANIFEST_PATH"; then
+        echo -e "${RED}Error: Failed to update SHA256 in manifest${NC}"
+        print_debug_info
+        exit 1
+    fi
     echo -e "${GREEN}Updated Node.js SHA256 in manifest${NC}"
-    
-    # Clean up downloaded file
-    rm -f "$tarball_path"
 }
 
 # Function to clean old builds
 clean_build() {
     echo "Cleaning previous build artifacts..."
     rm -rf "$BUILD_DIR" "$REPO_DIR"
+}
+
+# Function to print debug information
+print_debug_info() {
+    echo -e "\n${YELLOW}=== Debug Information ===${NC}"
+    echo "Working directory: $(pwd)"
+    echo "Manifest path: $MANIFEST_PATH"
+    echo "Build directory: $BUILD_DIR"
+    echo "Cache directory: $CACHE_DIR"
+    echo "Node.js version: $NODE_VERSION"
+    
+    # Check if downloads directory exists
+    local download_dir="$(dirname "$MANIFEST_PATH")/downloads"
+    echo "Downloads directory: $download_dir"
+    if [ -d "$download_dir" ]; then
+        echo "Downloads directory contents:"
+        ls -la "$download_dir"
+    else
+        echo "Downloads directory does not exist!"
+    fi
+    
+    # Check manifest file
+    echo -e "\nManifest file contents:"
+    cat "$MANIFEST_PATH"
+    
+    # Check system resources
+    echo -e "\nSystem resources:"
+    df -h .
+    free -h
+    
+    echo -e "\n${YELLOW}=== End Debug Information ===${NC}\n"
 }
 
 # Function to run the build
@@ -76,25 +136,44 @@ run_build() {
     # Create cache directory if it doesn't exist
     mkdir -p "$CACHE_DIR"
     
-    # Run the build with cache
-    if flatpak-builder \
+    # Verify Node.js tarball exists
+    local download_dir="$(dirname "$MANIFEST_PATH")/downloads"
+    local tarball_path="$download_dir/node-v${NODE_VERSION}-linux-x64.tar.xz"
+    if [ ! -f "$tarball_path" ]; then
+        echo -e "${RED}Error: Node.js tarball not found at: $tarball_path${NC}"
+        echo "This file should have been downloaded during the SHA256 check."
+        print_debug_info
+        exit 1
+    fi
+    
+    # Run the build with cache and capture output
+    echo "Running Flatpak builder..."
+    local build_output
+    if build_output=$(flatpak-builder \
         --repo="$REPO_DIR" \
         --force-clean \
         --state-dir="$CACHE_DIR" \
         "$BUILD_DIR" \
-        "$MANIFEST_PATH"; then
+        "$MANIFEST_PATH" 2>&1); then
+        
         echo -e "${GREEN}Build completed successfully!${NC}"
         
         # Create Flatpak bundle
         echo "Creating Flatpak bundle..."
-        flatpak build-bundle \
+        if flatpak build-bundle \
             "$REPO_DIR" \
             frigate-config-gui.flatpak \
-            com.frigateNVR.ConfigGUI
-        
-        echo -e "${GREEN}Flatpak bundle created: frigate-config-gui.flatpak${NC}"
+            com.frigateNVR.ConfigGUI; then
+            echo -e "${GREEN}Flatpak bundle created: frigate-config-gui.flatpak${NC}"
+        else
+            echo -e "${RED}Failed to create Flatpak bundle!${NC}"
+            print_debug_info
+            exit 1
+        fi
     else
-        echo -e "${RED}Build failed!${NC}"
+        echo -e "${RED}Build failed! Error output:${NC}"
+        echo "$build_output"
+        print_debug_info
         exit 1
     fi
 }
@@ -102,11 +181,19 @@ run_build() {
 # Main execution
 main() {
     echo "=== Frigate Config GUI Build Script ==="
+    echo "Debug mode: ${DEBUG}"
+    echo "Force download: ${FORCE_DOWNLOAD}"
     
     check_dependencies
     update_node_sha256
     clean_build
     run_build
+    
+    # Show debug info if requested
+    if [ "${DEBUG}" = "true" ]; then
+        echo -e "\n${YELLOW}=== Final Build State ===${NC}"
+        print_debug_info
+    fi
     
     echo -e "${GREEN}All done! You can find the Flatpak bundle at: frigate-config-gui.flatpak${NC}"
 }


### PR DESCRIPTION
This PR improves the build script with better error handling and debugging capabilities.

Changes:
1. Added comprehensive debug information output:
   - Working directory and paths
   - Downloads directory contents
   - Manifest file contents
   - System resources (disk space, memory)
2. Added environment variables for configuration:
   - `FORCE_DOWNLOAD=true` to force re-download of Node.js
   - `DEBUG=true` to show debug info even on success
3. Improved error messages with context
4. Added script documentation and usage examples
5. Fixed Node.js tarball handling to keep the file for Flatpak

Example usage:
```bash
# Normal build
./build.sh

# Force re-download Node.js and show debug info
DEBUG=true FORCE_DOWNLOAD=true ./build.sh
```

When errors occur, the script now provides detailed information to help diagnose the issue.