### PR TITLE
Fix syntax error in build script

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -179,7 +179,6 @@ print_debug_info() {
     
     echo -e "\n${YELLOW}=== End Debug Information ===${NC}\n"
 }
-}
 
 # Function to run the build
 run_build() {


### PR DESCRIPTION
This PR fixes a syntax error in the build script that was causing it to fail.

Changes:
- Removed an extra closing brace that was causing a syntax error

The script should now run without the `syntax error near unexpected token }` error.