### PR TITLE
build: Fix Node.js SDK extension setup

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -13,6 +13,12 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Install Node.js SDK extension
+        run: |
+          flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install -y flathub org.freedesktop.Sdk.Extension.node20//24.08
+      
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: frigate-config-gui.flatpak

--- a/flatpak/com.frigateNVR.ConfigGUI.yml
+++ b/flatpak/com.frigateNVR.ConfigGUI.yml
@@ -24,6 +24,9 @@ finish-args:
 build-options:
   env:
     NPM_CONFIG_LOGLEVEL: info
+  append-path: /usr/lib/sdk/node20/bin
+  prepend-pkg-config-path: /usr/lib/sdk/node20/lib/pkgconfig
+  prepend-ld-library-path: /usr/lib/sdk/node20/lib
 
 cleanup:
   - /include
@@ -38,11 +41,14 @@ modules:
     buildsystem: simple
     build-commands:
       - |
-        # Enable Node.js SDK extension
+        # Set up Node.js environment
         . /usr/lib/sdk/node20/enable.sh
+        export FLATPAK_BUILDER_BUILDDIR="$PWD"
+        export FLATPAK_ID="com.frigateNVR.ConfigGUI"
 
         # Install dependencies and build
-        npm ci
+        npm config set prefix /app
+        npm ci --offline --cache=/run/build/frigate-config-gui/npm-cache
         npm run build
 
         # Install application
@@ -61,6 +67,8 @@ modules:
         # Create wrapper script
         cat > /app/bin/frigate-config-gui-wrapper << 'EOL'
         #!/bin/sh
+        export PATH="/app/bin:$PATH"
+        export NODE_PATH="/app/lib/node_modules"
         exec /app/bin/frigate-config-gui "$@"
         EOL
         chmod +x /app/bin/frigate-config-gui-wrapper


### PR DESCRIPTION
This PR fixes the Node.js SDK extension setup in the build system:

1. Adds explicit installation of Node.js SDK extension in GitHub Actions:
   ```yaml
   - name: Install Node.js SDK extension
     run: |
       flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
       flatpak install -y flathub org.freedesktop.Sdk.Extension.node20//24.08
   ```

2. Improves Flatpak manifest:
   - Adds proper build environment variables
   - Sets up npm paths correctly
   - Uses offline npm cache
   - Exports necessary environment variables

These changes should fix the build error by ensuring that:
1. The Node.js SDK extension is installed before building
2. The build environment is properly configured
3. npm has the correct permissions and paths