### PR TITLE
Fix build issues and add TypeScript configuration

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -20,10 +20,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
 
-      - name: Add Flathub remote
+      - name: Add Flathub remote and install dependencies
         run: |
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+          sudo flatpak install -y flathub \
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08 \
+            org.freedesktop.Sdk.Extension.node20//24.08
 
       - name: Build Flatpak
         run: |


### PR DESCRIPTION
This PR fixes several build issues:

1. Flatpak Build:
- Add Node.js SDK extension installation to GitHub Actions workflow
- Make workflow names more distinct to avoid confusion

2. TypeScript Type Checking:
- Add tsconfig.json with appropriate configuration for React and TypeScript
- Enable strict type checking
- Configure module resolution and paths

The build was failing with these errors:
```
Requested extension org.freedesktop.Sdk.Extension.node20/x86_64/24.08 not installed
```
and
```
tsc: The TypeScript Compiler - Version 5.7.3
```

This PR fixes both issues by:
1. Explicitly installing the required SDK extension in the GitHub Actions workflow
2. Adding a proper TypeScript configuration file