### PR TITLE
Fix TypeScript configuration paths

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,12 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["electron-app/src/*"],
+      "@main/*": ["electron-app/src/main/*"],
+      "@renderer/*": ["electron-app/src/renderer/*"],
+      "@shared/*": ["electron-app/src/shared/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["electron-app/src/**/*"],
   "exclude": ["node_modules", "build", "dist"]
 }


### PR DESCRIPTION
This PR fixes the TypeScript configuration to match the project structure:

1. Update include path to `electron-app/src/**/*` to match where the TypeScript files are located
2. Add path aliases for better imports:
   - `@/*` -> `electron-app/src/*`
   - `@main/*` -> `electron-app/src/main/*`
   - `@renderer/*` -> `electron-app/src/renderer/*`
   - `@shared/*` -> `electron-app/src/shared/*`

This fixes the error:
```
error TS18003: No inputs were found in config file
```

The configuration now correctly points to the TypeScript files in the electron app directory.