### PR TITLE
fix: Use user-level Flatpak installation in GitHub Actions

### DIFF
--- a/.github/workflows/release-flatpak.yml
+++ b/.github/workflows/release-flatpak.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
-          flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 org.freedesktop.Sdk.Extension.node20//24.08
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 org.freedesktop.Sdk.Extension.node20//24.08
       
       - name: Build Flatpak
         run: |


### PR DESCRIPTION
This PR fixes the Flatpak installation issues in the release workflow by:

- Using user-level Flatpak installation instead of system-wide
- Removing unnecessary sudo from Flatpak commands
- Keeping sudo only for apt-get commands which require it

This should resolve the "Flatpak system operation ConfigureRemote not allowed for user" error.