### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,14 +5,32 @@ on:
     types: [created]
 
 jobs:
+  version:
+    name: Inject Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set version
+        id: set-version
+        run: |
+          VERSION=$(node tools/update-version.js)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   flatpak:
     name: "Flatpak"
+    needs: version
     runs-on: ubuntu-latest
     container:
       image: bilelmoussaoui/flatpak-github-actions:freedesktop-24.08
       options: --privileged
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Inject version
+        run: |
+          sed -i "s/version:.*/version: ${{ needs.version.outputs.version }}/" flatpak/com.frigateNVR.ConfigGUI.yml
       
       - name: Install Node.js SDK extension
         run: |
@@ -31,15 +49,33 @@ jobs:
           path: frigate-config-gui.flatpak
           retention-days: 7
 
-  electron:
-    name: "Electron Build"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+  electron-linux:
+    name: "Electron Linux"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: version
+
+electron-windows:
+    name: "Electron Windows"
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    needs: version
+
+electron-macos:
+    name: "Electron MacOS"
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    needs: version
 
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Inject version
+        run: |
+          sed -i "s/\"version\":.*/\"version\": \"${{ needs.version.outputs.version }}\",/" package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -68,7 +104,7 @@ jobs:
           retention-days: 7
 
       - name: Upload to release
-        if: github.event_name == 'release'
+        if: github.event.release.published_at != null
         uses: softprops/action-gh-release@v1
         with:
           files: |
@@ -78,5 +114,8 @@ jobs:
             dist/*.rpm
             dist/*.exe
             dist/*.dmg
+          tag_name: ${{ github.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+          contents: write


### PR DESCRIPTION
Addresses PR #47 issues by:
- Adding version injection from tools/update-version.js
- Splitting matrix into parallel jobs
- Adding proper permissions
- Improving cache keys
- Fixing release upload conditions