### PR TITLE
chore(ci/docs): add disclosures, mergeability guard, and OpenSSF Scorecard

### DIFF
--- a/.github/workflows/mergeability-check.yml
+++ b/.github/workflows/mergeability-check.yml
@@ -19,13 +19,18 @@ jobs:
         run: |
           git fetch origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-branch"
+      - name: Configure git identity (for non-committing merges)
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
       - name: Simulate merge of PR into base
         run: |
           git checkout -B test-merge "origin/${{ github.base_ref }}"
-          if git merge --no-commit --no-ff pr-branch; then
+          if git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" merge --no-commit --no-ff pr-branch; then
             echo "Merge is clean."
           else
-            echo "Merge conflicts detected. Please rebase or merge latest '${{ github.base_ref }}' into your branch and resolve conflicts."
-            git merge --abort || true
+            echo "Merge conflicts or merge error detected. Attempting to abort if merge in progress..."
+            if [ -f .git/MERGE_HEAD ]; then git merge --abort; fi
+            echo "Please rebase or merge latest '${{ github.base_ref }}' into your branch and resolve conflicts."
             exit 1
           fi

--- a/.github/workflows/mergeability-check.yml
+++ b/.github/workflows/mergeability-check.yml
@@ -1,0 +1,31 @@
+name: Mergeability Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-merge-conflicts:
+    name: Detect merge conflicts with base branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout (fetch-depth 0)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch base and PR head
+        run: |
+          git fetch origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-branch"
+      - name: Simulate merge of PR into base
+        run: |
+          git checkout -B test-merge "origin/${{ github.base_ref }}"
+          if git merge --no-commit --no-ff pr-branch; then
+            echo "Merge is clean."
+          else
+            echo "Merge conflicts detected. Please rebase or merge latest '${{ github.base_ref }}' into your branch and resolve conflicts."
+            git merge --abort || true
+            exit 1
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '34 14 * * 2' # weekly, Tuesday
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Needed for OIDC to submit results
+  security-events: write # Needed for uploading results to code scanning dashboard
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload Scorecard results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openssf-scorecard
+          path: results.sarif
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project is in early alpha development and is currently:
 - Not thoroughly tested in production environments
 - Missing some planned features
 - Subject to significant UI/UX changes
+- Built in the open with a vibe-coded approach in early phases; see disclosures below
+
 
 A professional desktop application for managing Frigate NVR configurations through an intuitive graphical interface. Built with modern web technologies and designed for reliability and ease of use.
 
@@ -19,6 +21,10 @@ A professional desktop application for managing Frigate NVR configurations throu
 [![Platform](https://img.shields.io/badge/Platform-Linux-green)](https://flathub.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-18.0-blue)](https://reactjs.org/)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/RyansOpenSourceRice/Frigate-Config-GUI?label=openssf%20scorecard)](https://securityscorecards.dev/viewer/?uri=github.com/RyansOpenSourceRice/Frigate-Config-GUI)
+[![Vibe Coded: Disclosure](https://img.shields.io/badge/Vibe%20Coded-Disclosure-informational?style=flat-square)](https://github.com/danielrosehill/Vibe-Coded-Disclosure)
+[![Non-Working State: Disclosure](https://img.shields.io/badge/Non--Working%20State-Disclosure-orange?style=flat-square)](docs/NON_WORKING_STATE.md)
+
 
 <!-- 
 Release checklist badge (add when available on Flathub):
@@ -125,6 +131,11 @@ This project follows Test-Driven Development (TDD) practices and uses modern too
 - TailwindCSS for styling
 - Vitest for testing
 - Electron for cross-platform support
+## Disclosures
+
+- Vibe-coded development may be present in early phases. See: https://github.com/danielrosehill/Vibe-Coded-Disclosure
+- Some components may be in a non-working state while under active development. See: [Non-Working State Disclosure](docs/NON_WORKING_STATE.md)
+
 
 ## Updates and Maintenance
 

--- a/docs/NON_WORKING_STATE.md
+++ b/docs/NON_WORKING_STATE.md
@@ -1,0 +1,20 @@
+# Non-Working State Disclosure
+
+This repository may contain code paths, features, or workflows that are incomplete, experimental, or currently non-functional. These parts are included to aid development and collaboration, but they are not guaranteed to work at this time.
+
+What this means:
+- Some features are stubbed or behind feature flags
+- Some build targets or packaging flows may be temporarily broken
+- Documentation may describe planned features that are still in progress
+- Issues and PRs labeled with `non-working` or `prefunctional` indicate known gaps
+
+How to help:
+- Open an issue clearly describing the non-working behavior and expected outcome
+- If you submit a PR, link to the issue and describe any limitations
+- Avoid depending on non-working parts in production environments
+
+Status transparency:
+- We strive to mark non-working areas in docs or code comments where feasible
+- CI will be configured to surface known breakages where appropriate
+
+See also: Vibe Coded Disclosure for context on early-stage, vibe-coded artifacts.


### PR DESCRIPTION
Summary
- Add vibe-coded and non-working state disclosures to README with badges
- Add NON_WORKING_STATE.md describing expectations and contribution guidance for incomplete/experimental areas
- Add "Mergeability Check" GitHub Action to detect and fail on PRs with merge conflicts against base
- Add OpenSSF Scorecard workflow and publish results to enable repository badge and Security tab integration

Details
1) Disclosures
- README now displays:
  - Vibe Coded: Disclosure badge (link to Vibe-Coded-Disclosure)
  - Non-Working State: Disclosure badge (link to docs/NON_WORKING_STATE.md)
  - OpenSSF Scorecard badge
- New docs/NON_WORKING_STATE.md: outlines the meaning of non-working state components and how to contribute.

2) Mergeability Guard CI
- .github/workflows/mergeability-check.yml: Simulates merging PR head into base and fails the job on conflicts. Encourages authors to rebase/merge main before requesting review.

3) OpenSSF Scorecard
- .github/workflows/scorecard.yml: Weekly schedule + push + manual dispatch.
- Publishes results (SARIF) to Security tab and enables badge.

Screenshots/Artifacts
- N/A (workflow-only + docs).

Checklist
- [x] CI passes or is expected to pass after first run on GitHub
- [x] Uses only open source actions/tools
- [x] No changes to application runtime code

Notes
- Consider enabling branch protection on main to require the Mergeability Check before merging PRs.
- Scorecard badge will display after first workflow execution.


@RyansOpenSourceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5b7f7530c9d2401b95dc090e85f1c60a)