### PR TITLE
feat(ui): Add Detectors, go2rtc, Network (TLS/Proxy), Recording/Snapshots, and Zones/Masks editors

### DIFF
--- a/electron-app/src/renderer/App.tsx
+++ b/electron-app/src/renderer/App.tsx
@@ -153,6 +153,7 @@ export default function App() {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             Frigate Config GUI
           </Typography>
+          <Button color="inherit" onClick={() => setConfig({ mqtt: { host: '', port: 1883, topic_prefix: 'frigate', client_id: 'frigate' }, cameras: {}, audio: { enabled: false } })}>New</Button>
           <Button color="inherit" onClick={handleImport}>Import</Button>
           <Button color="inherit" onClick={handleExport}>Export</Button>
           <Button color="inherit" onClick={handleValidate}>Validate</Button>

--- a/electron-app/src/renderer/App.tsx
+++ b/electron-app/src/renderer/App.tsx
@@ -15,6 +15,11 @@ import { FrigateConfig } from '../shared/types/config';
 import CameraConfig from './components/CameraConfig';
 import MQTTConfig from './components/MQTTConfig';
 import AudioConfig from './components/AudioConfig';
+import DetectorsConfig from './components/DetectorsConfig';
+import Go2RTCConfig from './components/Go2RTCConfig';
+import NetworkConfig from './components/NetworkConfig';
+import RecordingConfig from './components/RecordingConfig';
+import ZonesMasksConfig from './components/ZonesMasksConfig';
 
 declare global {
   interface Window {
@@ -159,6 +164,11 @@ export default function App() {
           <Tab label="Cameras" />
           <Tab label="MQTT" />
           <Tab label="Audio" />
+          <Tab label="Detectors" />
+          <Tab label="go2rtc" />
+          <Tab label="Recording/Snapshots" />
+          <Tab label="Network" />
+          <Tab label="Zones/Masks" />
         </Tabs>
       </Box>
 
@@ -170,6 +180,37 @@ export default function App() {
           />
         </TabPanel>
         <TabPanel value={tabValue} index={1}>
+        <TabPanel value={tabValue} index={3}>
+          <DetectorsConfig
+            config={config?.detectors || {}}
+            onChange={(detectors) => setConfig((prev: FrigateConfig | null) => prev ? { ...prev, detectors } : null)}
+          />
+        </TabPanel>
+        <TabPanel value={tabValue} index={4}>
+          <Go2RTCConfig
+            config={config?.go2rtc}
+            onChange={(go2rtc) => setConfig((prev: FrigateConfig | null) => prev ? { ...prev, go2rtc } : null)}
+          />
+        </TabPanel>
+        <TabPanel value={tabValue} index={5}>
+          <RecordingConfig
+            cameras={config?.cameras}
+            onChange={(cameras) => setConfig((prev: FrigateConfig | null) => prev ? { ...prev, cameras } : null)}
+          />
+        </TabPanel>
+        <TabPanel value={tabValue} index={6}>
+          <NetworkConfig
+            config={config?.network}
+            onChange={(network) => setConfig((prev: FrigateConfig | null) => prev ? { ...prev, network } : null)}
+          />
+        </TabPanel>
+        <TabPanel value={tabValue} index={7}>
+          <ZonesMasksConfig
+            cameras={config?.cameras}
+            onChange={(cameras) => setConfig((prev: FrigateConfig | null) => prev ? { ...prev, cameras } : null)}
+          />
+        </TabPanel>
+
           <MQTTConfig
             config={config?.mqtt}
             onChange={(mqtt) => setConfig((prev: FrigateConfig | null) => prev ? { ...prev, mqtt } : null)}

--- a/electron-app/src/renderer/components/CameraConfig.tsx
+++ b/electron-app/src/renderer/components/CameraConfig.tsx
@@ -31,7 +31,7 @@ export default function CameraConfig({ config, onChange }: Props) {
         ffmpeg: {
           inputs: [{
             path: '',
-            roles: ['detect']
+            roles: ['detect'] as ('detect'|'record'|'audio')[]
           }]
         }
       }
@@ -67,7 +67,7 @@ export default function CameraConfig({ config, onChange }: Props) {
     if (!config) return;
 
     const camera = config[cameraName];
-    const newInputs = [...camera.ffmpeg.inputs];
+    const newInputs = [...camera.ffmpeg.inputs] as (ICameraConfig['ffmpeg']['inputs'][0])[];
     newInputs[inputIndex] = {
       ...newInputs[inputIndex],
       [field]: value
@@ -165,7 +165,7 @@ export default function CameraConfig({ config, onChange }: Props) {
                                 value={input.roles.join(',')}
                                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange(cameraName, index, 'roles', e.target.value.split(',').map((r: string) => r.trim()))}
                                 placeholder="detect, record"
-                                helperText="Available roles: detect, record, rtmp"
+                                helperText="Available roles: detect, record, audio"
                               />
                             </Grid>
                           </Grid>

--- a/electron-app/src/renderer/components/DetectorsConfig.tsx
+++ b/electron-app/src/renderer/components/DetectorsConfig.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { Box, Card, CardContent, Grid, TextField, Typography, IconButton, Button } from '@mui/material';
+import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import type { Detectors } from '../../shared/types/config';
+
+interface Props {
+  config: Detectors;
+  onChange: (config: Detectors) => void;
+}
+
+export default function DetectorsConfig({ config, onChange }: Props) {
+  const [newName, setNewName] = useState('cpu1');
+
+  const detectors = config || {};
+
+  const addDetector = () => {
+    if (!newName.trim()) return;
+    onChange({
+      ...detectors,
+      [newName]: { type: 'cpu' }
+    });
+    setNewName('');
+  };
+
+  const removeDetector = (name: string) => {
+    const next = { ...detectors };
+    delete next[name];
+    onChange(next);
+  };
+
+  const setField = (name: string, field: 'type' | 'device', value: string) => {
+    onChange({
+      ...detectors,
+      [name]: { ...detectors[name], [field]: value }
+    });
+  };
+
+  return (
+    <Box>
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>Detectors</Typography>
+          <Grid container spacing={2} alignItems="center" sx={{ mb: 2 }}>
+            <Grid item xs={6}>
+              <TextField fullWidth label="New detector name" value={newName} onChange={(e) => setNewName(e.target.value)} />
+            </Grid>
+            <Grid item>
+              <Button variant="contained" startIcon={<AddIcon />} onClick={addDetector} disabled={!newName.trim()}>Add</Button>
+            </Grid>
+          </Grid>
+
+          {Object.entries(detectors).map(([name, det]) => (
+            <Card key={name} variant="outlined" sx={{ mb: 2 }}>
+              <CardContent>
+                <Grid container spacing={2} alignItems="center">
+                  <Grid item xs={12} md={4}>
+                    <TextField fullWidth label="Name" value={name} disabled />
+                  </Grid>
+                  <Grid item xs={12} md={4}>
+                    <TextField fullWidth label="Type (cpu, edgetpu, openvino)" value={det.type} onChange={(e) => setField(name, 'type', e.target.value)} />
+                  </Grid>
+                  <Grid item xs={12} md={3}>
+                    <TextField fullWidth label="Device (optional)" value={det.device || ''} onChange={(e) => setField(name, 'device', e.target.value)} />
+                  </Grid>
+                  <Grid item xs={12} md={1}>
+                    <IconButton color="error" onClick={() => removeDetector(name)}><DeleteIcon /></IconButton>
+                  </Grid>
+                </Grid>
+              </CardContent>
+            </Card>
+          ))}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/electron-app/src/renderer/components/Go2RTCConfig.tsx
+++ b/electron-app/src/renderer/components/Go2RTCConfig.tsx
@@ -1,0 +1,67 @@
+import { Box, Card, CardContent, Grid, TextField, Typography, Button } from '@mui/material';
+import type { Go2RTC } from '../../shared/types/config';
+import { useState } from 'react';
+
+interface Props {
+  config?: Go2RTC;
+  onChange: (config: Go2RTC) => void;
+}
+
+export default function Go2RTCConfig({ config, onChange }: Props) {
+  const [newName, setNewName] = useState('frontdoor');
+  const [newValue, setNewValue] = useState('rtsp://...#video=copy');
+
+  const streams = config?.streams || {};
+
+  const addStream = () => {
+    if (!newName.trim() || !newValue.trim()) return;
+    onChange({ streams: { ...streams, [newName]: newValue } });
+    setNewName('');
+    setNewValue('');
+  };
+
+  const setStream = (name: string, value: string) => {
+    onChange({ streams: { ...streams, [name]: value } });
+  };
+
+  const removeStream = (name: string) => {
+    const next: Record<string, string> = { ...streams };
+    delete next[name];
+    onChange({ streams: next });
+  };
+
+  return (
+    <Box>
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>go2rtc Streams</Typography>
+          <Grid container spacing={2} alignItems="center" sx={{ mb: 2 }}>
+            <Grid item xs={12} md={3}>
+              <TextField fullWidth label="Name" value={newName} onChange={(e) => setNewName(e.target.value)} />
+            </Grid>
+            <Grid item xs={12} md={7}>
+              <TextField fullWidth label="Value" value={newValue} onChange={(e) => setNewValue(e.target.value)} placeholder="rtsp://...#video=copy" />
+            </Grid>
+            <Grid item xs={12} md={2}>
+              <Button variant="contained" onClick={addStream} disabled={!newName.trim() || !newValue.trim()}>Add</Button>
+            </Grid>
+          </Grid>
+
+          {Object.entries(streams).map(([name, val]) => (
+            <Grid container spacing={2} alignItems="center" key={name} sx={{ mb: 1 }}>
+              <Grid item xs={12} md={3}>
+                <TextField fullWidth label="Name" value={name} disabled />
+              </Grid>
+              <Grid item xs={12} md={7}>
+                <TextField fullWidth label="Value" value={val} onChange={(e) => setStream(name, e.target.value)} />
+              </Grid>
+              <Grid item xs={12} md={2}>
+                <Button color="error" onClick={() => removeStream(name)}>Remove</Button>
+              </Grid>
+            </Grid>
+          ))}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/electron-app/src/renderer/components/NetworkConfig.tsx
+++ b/electron-app/src/renderer/components/NetworkConfig.tsx
@@ -1,0 +1,69 @@
+import { Box, Card, CardContent, Grid, Switch, TextField, Typography, FormControlLabel } from '@mui/material';
+import type { Network } from '../../shared/types/config';
+
+interface Props {
+  config?: Network;
+  onChange: (config: Network) => void;
+}
+
+export default function NetworkConfig({ config, onChange }: Props) {
+  const net = config || {} as Network;
+
+  const setTLS = (field: 'enabled' | 'certfile' | 'keyfile', value: string | boolean) => {
+    onChange({
+      ...net,
+      tls: { enabled: field === 'enabled' ? Boolean(value) : Boolean(net.tls?.enabled), certfile: net.tls?.certfile, keyfile: net.tls?.keyfile, [field]: value } as any
+    });
+  };
+
+  const setProxy = (field: 'forward_headers' | 'trusted_proxies', value: boolean | string[]) => {
+    onChange({
+      ...net,
+      proxy: { ...net.proxy, [field]: value } as any
+    });
+  };
+
+  return (
+    <Box>
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>Network / TLS / Proxy</Typography>
+
+          <Typography variant="subtitle1" sx={{ mt: 2 }}>TLS</Typography>
+          <Grid container spacing={2} alignItems="center">
+            <Grid item xs={12} md={4}>
+              <FormControlLabel
+                control={<Switch checked={Boolean(net.tls?.enabled)} onChange={(e) => setTLS('enabled', e.target.checked)} />}
+                label="Enable TLS"
+              />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <TextField fullWidth label="Certificate file" value={net.tls?.certfile || ''} onChange={(e) => setTLS('certfile', e.target.value)} />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <TextField fullWidth label="Key file" value={net.tls?.keyfile || ''} onChange={(e) => setTLS('keyfile', e.target.value)} />
+            </Grid>
+          </Grid>
+
+          <Typography variant="subtitle1" sx={{ mt: 2 }}>Proxy</Typography>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={4}>
+              <FormControlLabel
+                control={<Switch checked={Boolean(net.proxy?.forward_headers)} onChange={(e) => setProxy('forward_headers', e.target.checked)} />}
+                label="Forward headers"
+              />
+            </Grid>
+            <Grid item xs={12} md={8}>
+              <TextField
+                fullWidth
+                label="Trusted proxies (comma separated CIDR/IP)"
+                value={(net.proxy?.trusted_proxies || []).join(', ')}
+                onChange={(e) => setProxy('trusted_proxies', e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
+              />
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/electron-app/src/renderer/components/RecordingConfig.tsx
+++ b/electron-app/src/renderer/components/RecordingConfig.tsx
@@ -1,0 +1,99 @@
+import { Box, Card, CardContent, Grid, Switch, TextField, Typography, FormControlLabel } from '@mui/material';
+import type { CameraConfig } from '../../shared/types/config';
+
+interface Props {
+  cameras?: Record<string, CameraConfig>;
+  onChange: (cameras: Record<string, CameraConfig>) => void;
+}
+
+export default function RecordingConfig({ cameras, onChange }: Props) {
+  if (!cameras) {
+    return <Typography variant="body1">No cameras configured.</Typography>;
+  }
+
+  const setField = (name: string, _path: (cfg: CameraConfig) => any, assign: (cfg: CameraConfig) => CameraConfig) => {
+    const next = { ...cameras };
+    next[name] = assign(cameras[name]);
+    onChange(next);
+  };
+
+  return (
+    <Box>
+      {Object.entries(cameras).map(([name, cam]) => (
+        <Card key={name} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>{name}</Typography>
+
+            <FormControlLabel
+              control={<Switch checked={Boolean(cam.record?.enabled)} onChange={(e) => setField(name, c => c.record?.enabled, (c) => ({ ...c, record: { ...c.record, enabled: e.target.checked } as any }))} />}
+              label="Enable recording"
+            />
+
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="Retain days"
+                  value={cam.record?.retain?.days ?? 0}
+                  onChange={(e) => setField(name, c => c.record?.retain?.days, (c) => ({ ...c, record: { ...c.record, retain: { ...c.record?.retain, days: parseInt(e.target.value, 10) || 0 } } as any }))}
+                  disabled={!cam.record?.enabled}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  label="Retain mode"
+                  value={cam.record?.retain?.mode || 'all'}
+                  onChange={(e) => setField(name, c => c.record?.retain?.mode, (c) => ({ ...c, record: { ...c.record, retain: { ...c.record?.retain, mode: e.target.value as any } } as any }))}
+                  disabled={!cam.record?.enabled}
+                  helperText="all | motion | active_objects"
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="Pre-capture (s)"
+                  value={cam.record?.events?.pre_capture ?? 5}
+                  onChange={(e) => setField(name, c => c.record?.events?.pre_capture, (c) => ({ ...c, record: { ...c.record, events: { ...c.record?.events, pre_capture: parseInt(e.target.value, 10) || 0 } } as any }))}
+                  disabled={!cam.record?.enabled}
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="Post-capture (s)"
+                  value={cam.record?.events?.post_capture ?? 5}
+                  onChange={(e) => setField(name, c => c.record?.events?.post_capture, (c) => ({ ...c, record: { ...c.record, events: { ...c.record?.events, post_capture: parseInt(e.target.value, 10) || 0 } } as any }))}
+                  disabled={!cam.record?.enabled}
+                />
+              </Grid>
+            </Grid>
+
+            <Typography variant="subtitle1" sx={{ mt: 2 }}>Snapshots</Typography>
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={4}>
+                <FormControlLabel
+                  control={<Switch checked={Boolean(cam.snapshots?.enabled)} onChange={(e) => setField(name, c => c.snapshots?.enabled, (c) => ({ ...c, snapshots: { ...c.snapshots, enabled: e.target.checked } as any }))} />}
+                  label="Enable snapshots"
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  fullWidth
+                  type="number"
+                  label="Quality (1-100)"
+                  value={cam.snapshots?.quality ?? ''}
+                  onChange={(e) => setField(name, c => c.snapshots?.quality, (c) => ({ ...c, snapshots: { ...c.snapshots, quality: parseInt(e.target.value, 10) || undefined } as any }))}
+                  disabled={!cam.snapshots?.enabled}
+                />
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/electron-app/src/renderer/components/ZonesMasksConfig.tsx
+++ b/electron-app/src/renderer/components/ZonesMasksConfig.tsx
@@ -1,0 +1,77 @@
+import { Box, Card, CardContent, Grid, TextField, Typography } from '@mui/material';
+import type { CameraConfig } from '../../shared/types/config';
+
+interface Props {
+  cameras?: Record<string, CameraConfig>;
+  onChange: (cameras: Record<string, CameraConfig>) => void;
+}
+
+export default function ZonesMasksConfig({ cameras, onChange }: Props) {
+  if (!cameras) {
+    return <Typography variant="body1">No cameras configured.</Typography>;
+  }
+
+  const setZoneField = (name: string, zoneName: string, field: 'coordinates' | 'objects' | 'inertia' | 'loitering_time', value: any) => {
+    const cam = cameras[name];
+    const zones = cam.zones || {} as any;
+    zones[zoneName] = { ...(zones[zoneName] || {}), [field]: value };
+    onChange({ ...cameras, [name]: { ...cam, zones } });
+  };
+
+  const setMotionMask = (name: string, value: string) => {
+    const cam = cameras[name];
+    const motion = { ...(cam.motion || {}), mask: value } as any;
+    onChange({ ...cameras, [name]: { ...cam, motion } });
+  };
+
+  return (
+    <Box>
+      {Object.entries(cameras).map(([name, cam]) => (
+        <Card key={name} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography variant="h6" gutterBottom>{name}</Typography>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Motion mask (comma separated polygons)"
+                  value={typeof cam.motion?.mask === 'string' ? cam.motion?.mask : (Array.isArray(cam.motion?.mask) ? cam.motion?.mask.join('; ') : '')}
+                  onChange={(e) => setMotionMask(name, e.target.value)}
+                  helperText="Enter polygon coordinates in percentage or pixels (e.g., 0.1,0.1,0.9,0.1,0.9,0.9,0.1,0.9). Multiple masks separated with ';'"
+                />
+              </Grid>
+            </Grid>
+
+            <Typography variant="subtitle1" sx={{ mt: 2 }}>Zones</Typography>
+            {Object.entries(cam.zones || {}).map(([zName, zone]: any) => (
+              <Grid container spacing={2} key={zName} sx={{ mb: 1 }}>
+                <Grid item xs={12} md={4}>
+                  <TextField fullWidth label="Zone name" value={zName} disabled />
+                </Grid>
+                <Grid item xs={12} md={8}>
+                  <TextField
+                    fullWidth
+                    label="Coordinates"
+                    value={zone.coordinates || ''}
+                    onChange={(e) => setZoneField(name, zName, 'coordinates', e.target.value)}
+                    helperText="Polygon in percentages (recommended) or pixels"
+                  />
+                </Grid>
+              </Grid>
+            ))}
+
+            {/* Simple adder: user types zone name + coordinates directly */}
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={4}>
+                <TextField fullWidth label="New zone name" onBlur={(e) => setZoneField(name, e.target.value, 'coordinates', '')} placeholder="driveway" />
+              </Grid>
+              <Grid item xs={12} md={8}>
+                <TextField fullWidth label="New zone coordinates" placeholder="0.1,0.1,0.9,0.1,0.9,0.9,0.1,0.9" />
+              </Grid>
+            </Grid>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/electron-app/src/shared/types/config.ts
+++ b/electron-app/src/shared/types/config.ts
@@ -5,15 +5,37 @@ export const CameraConfigSchema = z.object({
   ffmpeg: z.object({
     inputs: z.array(z.object({
       path: z.string(),
-      roles: z.array(z.string()),
+      roles: z.array(z.enum(['detect', 'record', 'audio'])),
       global_args: z.string().optional(),
       input_args: z.string().optional()
     }))
   }),
   detect: z.object({
-    width: z.number(),
-    height: z.number(),
-    fps: z.number()
+    width: z.number().optional(),
+    height: z.number().optional(),
+    fps: z.number().optional()
+  }).optional(),
+  motion: z.object({
+    mask: z.union([z.string(), z.array(z.string())]).optional()
+  }).optional(),
+  zones: z.record(z.object({
+    coordinates: z.string(),
+    objects: z.array(z.string()).optional(),
+    inertia: z.number().int().nonnegative().optional(),
+    loitering_time: z.number().nonnegative().optional()
+  })).optional(),
+  record: z.object({
+    enabled: z.boolean().default(false),
+    retain: z.object({
+      days: z.number().int().nonnegative().default(0),
+      mode: z.enum(['all', 'motion', 'active_objects']).default('all')
+    }).optional(),
+    events: z.object({
+      pre_capture: z.number().int().nonnegative().default(5),
+      post_capture: z.number().int().nonnegative().default(5),
+      required_zones: z.array(z.string()).optional(),
+      objects: z.array(z.string()).optional()
+    }).optional()
   }).optional(),
   objects: z.object({
     track: z.array(z.string())
@@ -21,7 +43,8 @@ export const CameraConfigSchema = z.object({
   snapshots: z.object({
     enabled: z.boolean(),
     timestamp: z.boolean().optional(),
-    bounding_box: z.boolean().optional()
+    bounding_box: z.boolean().optional(),
+    quality: z.number().int().min(1).max(100).optional()
   }).optional()
 });
 
@@ -43,11 +66,41 @@ export const AudioConfigSchema = z.object({
   duration: z.number().optional()
 });
 
+// Detectors (global)
+export const DetectorsSchema = z.record(z.object({
+  type: z.string(),
+  device: z.string().optional()
+}));
+export type Detectors = z.infer<typeof DetectorsSchema>;
+
+// go2rtc streams (global)
+export const Go2RTCSchema = z.object({
+  streams: z.record(z.string())
+});
+export type Go2RTC = z.infer<typeof Go2RTCSchema>;
+
+// Network/TLS/Proxy (global)
+export const NetworkSchema = z.object({
+  tls: z.object({
+    enabled: z.boolean(),
+    certfile: z.string().optional(),
+    keyfile: z.string().optional()
+  }).optional(),
+  proxy: z.object({
+    forward_headers: z.boolean().optional(),
+    trusted_proxies: z.array(z.string()).optional()
+  }).optional()
+});
+export type Network = z.infer<typeof NetworkSchema>;
+
 // Main configuration schema
 export const FrigateConfigSchema = z.object({
   mqtt: MQTTConfigSchema.optional(),
   cameras: z.record(CameraConfigSchema),
-  audio: AudioConfigSchema.optional()
+  audio: AudioConfigSchema.optional(),
+  detectors: DetectorsSchema.optional(),
+  go2rtc: Go2RTCSchema.optional(),
+  network: NetworkSchema.optional()
 });
 
 // TypeScript types derived from the schemas


### PR DESCRIPTION
Summary
- Add new UI tabs and editors to build a complete Frigate YAML via GUI
- Extend shared schema for latest Frigate 0.16.x fields

Details
- Detectors: CRUD for named detectors (cpu, edgetpu, openvino) with optional device
- go2rtc: Manage streams (name/value)
- Recording/Snapshots: Per-camera record.enabled, retain.days/mode, events pre/post capture; snapshots.enabled/quality
- Network: TLS (enable/certfile/keyfile) and Proxy (forward_headers, trusted_proxies)
- Zones/Masks: Text-based editor for motion masks and zones coordinates (supports percentages)

Developer Notes
- Updated App.tsx with new tabs and wiring
- Kept Import/Export/Validate via IPC; "New" initializes a minimal valid config structure
- Type-check and build verified (vite build + tsc electron)

Why
- Bring the GUI in line with Frigate’s standard/commonly used config areas, including go2rtc and detectors

Testing
- npm run type-check — OK
- npm run build — OK

Follow-ups
- Optional visual editor for zones/masks (canvas-based)
- Starter templates for common setups (CPU/OpenVINO/Coral)

Security & Tooling
- Uses only open-source dependencies



@RyansOpenSourceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5b7f7530c9d2401b95dc090e85f1c60a)