### PR TITLE
ci(scorecard): Fix workflow permissions to satisfy OpenSSF Scorecard verification

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,14 +7,15 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write # Needed for OIDC to submit results
-  security-events: write # Needed for uploading results to code scanning dashboard
+permissions: read-all
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary
- Update OpenSSF Scorecard workflow to meet workflow restrictions and prevent publishing failures.

What changed
- Top-level permissions set to `read-all`.
- Job-level permissions define:
  - `contents: read`
  - `id-token: write` (needed for OIDC / publishing results)
  - `security-events: write` (for uploading SARIF)

Why
- Scorecard action failed with `workflow verification failed: global perm is set to write: permission for id-token is set to write`.
- Moving write permissions to the job level satisfies Scorecard's verification policy.

References
- https://github.com/ossf/scorecard-action#workflow-restrictions

Impact
- Unblocks Scorecard results publication and Code Scanning SARIF upload on `push` to `main` and on the weekly schedule.



@RyansOpenSourceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5b7f7530c9d2401b95dc090e85f1c60a)